### PR TITLE
Data file structure

### DIFF
--- a/src/arc_tiptoe/preprocessing/clustering/clustering.py
+++ b/src/arc_tiptoe/preprocessing/clustering/clustering.py
@@ -47,7 +47,6 @@ class Clusterer(ABC):
             self.logger.info("Clustering already complete")
         else:
             self.logger.info("Clustering not yet complete, starting clustering")
-            self.config.clustering_path = f"data/{self.config.uuid}/clustering"
             self.processing_path = os.path.join(
                 self.config.clustering_path, "processing"
             )

--- a/src/arc_tiptoe/preprocessing/embedding/embedding.py
+++ b/src/arc_tiptoe/preprocessing/embedding/embedding.py
@@ -44,10 +44,6 @@ class Embedder(ABC):
             if within_pipeline:
                 self._return_config_in_pipeline()
         else:
-            self.gen_directory_structure()
-            self.config.embeddings_path = os.path.join(
-                "data", self.config.uuid, "embedding", "embeddings"
-            )
             self.dataset = None
             self.device = "cpu"
             if self.config.embed_pars.get("use_gpu", True):

--- a/src/arc_tiptoe/preprocessing/utils/config.py
+++ b/src/arc_tiptoe/preprocessing/utils/config.py
@@ -103,10 +103,8 @@ class PreProcessConfig:
         # load config from existing or create new config
         self._load_config(config_path)
 
-        if not self._check_for_config(config_path):
-            # create directory structure
-            self.uuid = self._gen_uuid()
-            self._gen_directory_structure()
+        # create directory structure
+        self._gen_directory_structure()
 
         logging.basicConfig(
             level=logging.INFO,


### PR DESCRIPTION
Small update so that the `embedding_path`, `clustering_path` and `dim_red_path` are only set in the `PreProcessConfig` class. This is to correct the following small issues:

- the `clustering_path` was named differently in `PreProcessConfig` and `clustering.py`
- the `dim_red_path` could get set to `None` if the process was stopped and restarted.