### PR TITLE
Clustering debugging

### DIFF
--- a/scripts/scratch.py
+++ b/scripts/scratch.py
@@ -1,0 +1,8 @@
+from arc_tiptoe.preprocessing.clustering.clustering import KMeansClusterer
+from arc_tiptoe.preprocessing.utils.config import PreProcessConfig
+
+json_config_path = "configs/distilbert_post_embedding.json"
+config = PreProcessConfig(json_config_path)
+
+clusterer = KMeansClusterer(config, within_pipeline=True)
+print('here')

--- a/src/arc_tiptoe/preprocessing/clustering/clustering.py
+++ b/src/arc_tiptoe/preprocessing/clustering/clustering.py
@@ -268,7 +268,7 @@ class Clusterer(ABC):
                 continue
 
             sub_elems_count += 1
-            sub_cluster_idx = total_elem_count + idx
+            sub_cluster_idx = total_elem_count + sub_elems_count + 1
             with open(
                 f"{self.processing_path}/processed_clusters/"
                 f"cluster_{sub_cluster_idx}.txt",

--- a/src/arc_tiptoe/preprocessing/clustering/clustering.py
+++ b/src/arc_tiptoe/preprocessing/clustering/clustering.py
@@ -55,7 +55,6 @@ class Clusterer(ABC):
             self.num_clusters = int(np.ceil(np.sqrt(len(self.embeddings))))
             self.config.cluster["num_clusters"] = self.num_clusters
             self.avg_sub_cluster_size = self.config.cluster["avg_sub_cluster_size"]
-            self.urls_per_bundle = self.config.cluster["urls_per_bundle"]
             self.max_size = self.config.cluster["max_size"]
             self.MULTI_ASSIGN = self.config.cluster.get("MULTI_ASSIGN", 2)
 


### PR DESCRIPTION
After doing the pre-processing, I tried running the test search command and got this error:

```
open ../data/c1970a4c-46c4-8fbe-cf94-d099e24ba206-None-192/clusters/cluster_2064.txt: no such file or directory
panic: Error opening file
 
goroutine 123 [running]:
github.com/ahenzinger/tiptoe/search/utils.OpenFile({0xc000022690?, 0x1a?})
       /bask/homes/q/qcax1583/vjgo8416-co-beagle/arc-tiptoe/search/utils/files.go:13 +0x78
github.com/ahenzinger/tiptoe/search/corpus.ReadEmbeddingsTxt(0x7e9, 0x816, 0xc00017c320)
       /bask/homes/q/qcax1583/vjgo8416-co-beagle/arc-tiptoe/search/corpus/read_corpus.go:136 +0x250
github.com/ahenzinger/tiptoe/search/protocol.NewEmbeddingServers.func2(0x0?)
       /bask/homes/q/qcax1583/vjgo8416-co-beagle/arc-tiptoe/search/protocol/server.go:142 +0x34
github.com/ahenzinger/tiptoe/search/protocol.launchServersFromLogs.func3(0x5)
       /bask/homes/q/qcax1583/vjgo8416-co-beagle/arc-tiptoe/search/protocol/server.go:264 +0xbf
created by github.com/ahenzinger/tiptoe/search/protocol.launchServersFromLogs in goroutine 1
       /bask/homes/q/qcax1583/vjgo8416-co-beagle/arc-tiptoe/search/protocol/server.go:262 +0x265
exit status 2
```

There was no cluster named `cluster_2064.txt`, but there was a `cluster_2063.txt` and `cluster_2065.txt`. There were also some other clusters that were skipped. 

This PR fixes the bug that was causing the missing cluster and also checks if the max size of a cluster is exceeded before sub-clustering
